### PR TITLE
fix: Replace -backup- container suffix with -dockmon-backup-

### DIFF
--- a/backend/docker_monitor/monitor.py
+++ b/backend/docker_monitor/monitor.py
@@ -1326,8 +1326,8 @@ class DockerMonitor:
 
             # Event-driven auto-restart: Check if container needs auto-restart on 'die' events
             if action == 'die':
-                # Skip backup containers (created during updates with -backup- suffix)
-                if '-backup-' in container_name:
+                # Skip backup containers (created during updates with -dockmon-backup- suffix)
+                if '-dockmon-backup-' in container_name:
                     logger.debug(f"Skipping auto-restart for {container_name} - backup container")
                     return
 
@@ -1511,8 +1511,8 @@ class DockerMonitor:
                 # Auto-restart reconciliation (safety net - events handle primary auto-restart)
                 # This catches containers that need restart if 'die' event was missed
                 for container in containers:
-                    # Skip backup containers (created during updates with -backup- suffix)
-                    if '-backup-' in container.name:
+                    # Skip backup containers (created during updates with -dockmon-backup- suffix)
+                    if '-dockmon-backup-' in container.name:
                         continue
 
                     if (container.status == "exited" and

--- a/backend/docker_monitor/periodic_jobs.py
+++ b/backend/docker_monitor/periodic_jobs.py
@@ -563,7 +563,7 @@ class PeriodicJobsManager:
         """
         Remove backup containers older than 24 hours.
 
-        Backup containers are created during updates with pattern: {name}-backup-{timestamp}
+        Backup containers are created during updates with pattern: {name}-dockmon-backup-{timestamp}
         If update succeeds, cleanup removes them. If cleanup fails, they accumulate.
         This job removes old backups to prevent disk bloat.
 
@@ -585,8 +585,8 @@ class PeriodicJobsManager:
                     containers = await async_docker_call(client.containers.list, all=True)
 
                     for container in containers:
-                        # Check if this is a backup container (pattern: {name}-backup-{timestamp})
-                        if '-backup-' not in container.name:
+                        # Check if this is a backup container (pattern: {name}-dockmon-backup-{timestamp})
+                        if '-dockmon-backup-' not in container.name:
                             continue
 
                         # Parse created timestamp

--- a/backend/updates/update_executor.py
+++ b/backend/updates/update_executor.py
@@ -1497,7 +1497,7 @@ class UpdateExecutor:
         try:
             # Generate backup name with timestamp
             timestamp = int(time.time())
-            backup_name = f"{original_name}-backup-{timestamp}"
+            backup_name = f"{original_name}-dockmon-backup-{timestamp}"
 
             logger.info(f"Creating backup: stopping and renaming {original_name} to {backup_name}")
 


### PR DESCRIPTION
Issue: The application uses a -backup- container name suffix when backing up container objects. Later this suffix is used to delete old backup containers. This may affect containers that are not related to DockMon.

Solution: Replace the -backup- suffix with -dockmon-backup-.

Impact: This will prevent unexpected container deletions, since the new suffix will for sure be used only by DockMon

Fixes: #75