### PR TITLE
fix: set correct permissions for certificate keys

### DIFF
--- a/scripts/setup-docker-mtls.sh
+++ b/scripts/setup-docker-mtls.sh
@@ -458,8 +458,8 @@ openssl x509 -req -days $DAYS_VALID -sha256 -in client.csr -CA ca.pem -CAkey ca-
 rm -f *.csr *.cnf ca.srl
 
 # Set appropriate permissions
-chmod 400 *-key.pem
 chmod 444 *.pem
+chmod 400 *-key.pem
 
 print_info "Certificates generated successfully!"
 echo ""


### PR DESCRIPTION
Currently in the `setup-docker-mtls.sh` script on line 461 the script sets the permissions for the keys to a restrictive read-only for the user, disallowing anything from groups and others, before that permission is being overwritten on line 462 to make all files with the `.pem` extension read-only for the owning user, group, and everyone else. 

The intention clearly was that the keys that were generated were only readable by the root user, but because of the more inclusive `*.pem` those permissions are being override. This PR fixes the order in which the changing of the file permissions is done to ensure that every pem certificate is read-only but also that the keys are only read-only by the root user and no one else, as they should be for security reasons. 