### PR TITLE
Added Google Chat as dedicated notification channel

### DIFF
--- a/backend/alerts/validator.py
+++ b/backend/alerts/validator.py
@@ -34,7 +34,7 @@ class AlertRuleValidator:
     VALID_SCOPES = {'host', 'container', 'group'}
     VALID_SEVERITIES = {'info', 'warning', 'error', 'critical'}
     VALID_OPERATORS = {'>=', '<=', '==', '>', '<', '!='}
-    VALID_NOTIFICATION_CHANNELS = {'slack', 'discord', 'telegram', 'pushover', 'gotify', 'ntfy', 'smtp', 'webhook', 'teams'}
+    VALID_NOTIFICATION_CHANNELS = {'slack', 'discord', 'telegram', 'pushover', 'gotify', 'ntfy', 'smtp', 'webhook', 'teams', 'google_chat'}
 
     # CPU metrics — can exceed 100% on multi-core containers
     CPU_METRICS = {

--- a/backend/models/request_models.py
+++ b/backend/models/request_models.py
@@ -171,7 +171,7 @@ class NotificationChannelCreate(BaseModel):
         if not v or not v.strip():
             raise ValueError('Channel type cannot be empty')
 
-        valid_types = {'telegram', 'discord', 'pushover', 'slack', 'gotify', 'ntfy', 'smtp', 'webhook', 'teams'}
+        valid_types = {'telegram', 'discord', 'pushover', 'slack', 'gotify', 'ntfy', 'smtp', 'webhook', 'teams', 'google_chat'}
         v = v.strip().lower()
 
         if v not in valid_types:
@@ -229,6 +229,16 @@ class NotificationChannelCreate(BaseModel):
             webhook_url = v.get('webhook_url', '')
             if not (webhook_url.startswith('http://') or webhook_url.startswith('https://')):
                 raise ValueError('Teams webhook URL must start with http:// or https://')
+
+        elif channel_type == 'google_chat':
+            required_keys = {'webhook_url'}
+            if not all(key in v for key in required_keys):
+                raise ValueError(f'Google Chat config must contain: {required_keys}')
+
+            # Google Chat space webhooks live under chat.googleapis.com
+            webhook_url = v.get('webhook_url', '')
+            if not webhook_url.startswith('https://chat.googleapis.com/'):
+                raise ValueError('Google Chat webhook URL must start with https://chat.googleapis.com/')
 
         elif channel_type == 'pushover':
             required_keys = {'app_token', 'user_key'}

--- a/backend/notifications.py
+++ b/backend/notifications.py
@@ -796,6 +796,57 @@ class NotificationService:
             logger.error(f"Failed to send Teams notification: {e}")
             return False
 
+    async def _send_google_chat(self, config: Dict[str, Any], message: str, event=None, action_url: str = '') -> bool:
+        """Send notification via Google Chat incoming webhook
+
+        Google Chat space webhooks accept a JSON payload with a `text` field
+        (markdown-formatted) or a `cardsV2` payload. We send `text` because the
+        same message string is reused across channels.
+
+        Args:
+            config: Google Chat channel configuration (webhook_url)
+            message: Formatted message to send (markdown supported)
+            event: Optional event object (unused, for signature consistency)
+            action_url: Optional action URL to append as a link
+        """
+        try:
+            webhook_url = config.get('webhook_url', '').strip()
+
+            if not webhook_url:
+                logger.error("Google Chat config missing webhook_url")
+                return False
+
+            if not webhook_url.startswith('https://chat.googleapis.com/'):
+                logger.error(f"Google Chat webhook_url must point to chat.googleapis.com: {webhook_url}")
+                return False
+
+            chat_message = message
+            if action_url:
+                chat_message += f"\n\n<{action_url}|Update Now>"
+
+            payload = {"text": chat_message}
+
+            response = await self.http_client.post(webhook_url, json=payload)
+            response.raise_for_status()
+
+            logger.info("Google Chat notification sent successfully")
+            return True
+
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 429:
+                retry_after = int(e.response.headers.get('Retry-After', 60))
+                retry_timestamp = datetime.now(timezone.utc) + timedelta(seconds=retry_after)
+                self._rate_limited_channels['google_chat'] = retry_timestamp
+                logger.warning(f"Google Chat rate limited, retry after {retry_after}s")
+            logger.error(f"Failed to send Google Chat notification: {e}")
+            return False
+        except httpx.RequestError as e:
+            logger.error(f"Google Chat connection error: {e}")
+            return False
+        except Exception as e:
+            logger.error(f"Failed to send Google Chat notification: {e}")
+            return False
+
     async def _send_webhook(self, config: Dict[str, Any], message: str, event=None, title: str = "DockMon Alert", action_url: str = '') -> bool:
         """Send notification via webhook (HTTP POST/PUT)
 
@@ -970,6 +1021,8 @@ class NotificationService:
                 success = await self._send_webhook(channel_config, test_message, test_event)
             elif channel_type == 'teams':
                 success = await self._send_teams(channel_config, test_message, test_event)
+            elif channel_type == 'google_chat':
+                success = await self._send_google_chat(channel_config, test_message, test_event)
             else:
                 return {"success": False, "error": f"Unsupported channel type: {channel_type}"}
 
@@ -1012,6 +1065,7 @@ class NotificationService:
                 'pushover': lambda: self._send_pushover(channel_config, message, None),
                 'teams': lambda: self._send_teams(channel_config, message),
                 'webhook': lambda: self._send_webhook(channel_config, message, title=title),
+                'google_chat': lambda: self._send_google_chat(channel_config, message),
             }
 
             sender = senders.get(channel_type)
@@ -1196,6 +1250,9 @@ class NotificationService:
                                 success_count += 1
                         elif channel.type == "teams":
                             if await self._send_teams(channel.config, message, action_url=action_url):
+                                success_count += 1
+                        elif channel.type == "google_chat":
+                            if await self._send_google_chat(channel.config, message, action_url=action_url):
                                 success_count += 1
                         else:
                             logger.warning(f"Unknown channel type '{channel.type}' for channel {channel.name}")

--- a/ui/src/features/alerts/components/AlertRuleFormModal.tsx
+++ b/ui/src/features/alerts/components/AlertRuleFormModal.tsx
@@ -6,7 +6,7 @@
 
 import { useState, useRef, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { X, Search, Check, Bell, BellRing, Send, MessageSquare, Hash, Smartphone, Mail, Globe, Users } from 'lucide-react'
+import { X, Search, Check, Bell, BellRing, Send, MessageSquare, MessageCircle, Hash, Smartphone, Mail, Globe, Users } from 'lucide-react'
 import { RemoveScroll } from 'react-remove-scroll'
 import { useCreateAlertRule, useUpdateAlertRule } from '../hooks/useAlertRules'
 import { useNotificationChannels } from '../hooks/useNotificationChannels'
@@ -186,6 +186,7 @@ const CHANNEL_TYPE_INFO: Record<string, { label: string; icon: typeof Bell }> = 
   discord: { label: 'Discord', icon: MessageSquare },
   slack: { label: 'Slack', icon: Hash },
   teams: { label: 'Microsoft Teams', icon: Users },
+  google_chat: { label: 'Google Chat', icon: MessageCircle },
   gotify: { label: 'Gotify', icon: Bell },
   ntfy: { label: 'ntfy', icon: BellRing },
   smtp: { label: 'Email', icon: Mail },

--- a/ui/src/features/alerts/components/ChannelForm.tsx
+++ b/ui/src/features/alerts/components/ChannelForm.tsx
@@ -6,7 +6,7 @@
 
 import { useState } from 'react'
 import { NotificationChannel, ChannelCreateRequest } from '../hooks/useNotificationChannels'
-import { Smartphone, Send, MessageSquare, Hash, Bell, BellRing, Mail, Webhook, Users } from 'lucide-react'
+import { Smartphone, Send, MessageSquare, MessageCircle, Hash, Bell, BellRing, Mail, Webhook, Users } from 'lucide-react'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 
 interface Props {
@@ -24,6 +24,7 @@ const CHANNEL_TYPES = [
   { value: 'discord', label: 'Discord', icon: MessageSquare },
   { value: 'slack', label: 'Slack', icon: Hash },
   { value: 'teams', label: 'Microsoft Teams (beta)', icon: Users },
+  { value: 'google_chat', label: 'Google Chat', icon: MessageCircle },
   { value: 'pushover', label: 'Pushover', icon: Smartphone },
   { value: 'gotify', label: 'Gotify', icon: Bell },
   { value: 'ntfy', label: 'ntfy', icon: BellRing },
@@ -92,6 +93,13 @@ export function ChannelForm({ channel, onSubmit, onCancel, onTest, isSubmitting,
       case 'teams':
         if (!formData.config.webhook_url) {
           newErrors['config.webhook_url'] = 'Webhook URL is required'
+        }
+        break
+      case 'google_chat':
+        if (!formData.config.webhook_url) {
+          newErrors['config.webhook_url'] = 'Webhook URL is required'
+        } else if (!formData.config.webhook_url.startsWith('https://chat.googleapis.com/')) {
+          newErrors['config.webhook_url'] = 'URL must start with https://chat.googleapis.com/'
         }
         break
       case 'pushover':
@@ -293,6 +301,23 @@ export function ChannelForm({ channel, onSubmit, onCancel, onTest, isSubmitting,
             {errors['config.webhook_url'] && <p className="mt-1 text-xs text-red-400">{errors['config.webhook_url']}</p>}
             <p className="mt-1 text-xs text-gray-400">
               Channel → Connectors → Incoming Webhook (or use Workflows)
+            </p>
+          </div>
+        )}
+
+        {formData.type === 'google_chat' && (
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">Webhook URL *</label>
+            <input
+              type="url"
+              value={formData.config.webhook_url || ''}
+              onChange={(e) => handleConfigChange('webhook_url', e.target.value)}
+              placeholder="https://chat.googleapis.com/v1/spaces/.../messages?key=...&token=..."
+              className={`w-full rounded-md border ${errors['config.webhook_url'] ? 'border-red-500' : 'border-gray-700'} bg-gray-800 px-3 py-2 text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500`}
+            />
+            {errors['config.webhook_url'] && <p className="mt-1 text-xs text-red-400">{errors['config.webhook_url']}</p>}
+            <p className="mt-1 text-xs text-gray-400">
+              In Google Chat space: Apps & integrations → Webhooks → Add webhook. Copy the full URL including key &amp; token.
             </p>
           </div>
         )}

--- a/ui/src/features/alerts/hooks/useNotificationChannels.ts
+++ b/ui/src/features/alerts/hooks/useNotificationChannels.ts
@@ -8,7 +8,7 @@ import { apiClient } from '@/lib/api/client'
 export interface NotificationChannel {
   id: number
   name: string
-  type: 'telegram' | 'discord' | 'slack' | 'pushover' | 'gotify' | 'ntfy' | 'smtp' | 'webhook'
+  type: 'telegram' | 'discord' | 'slack' | 'teams' | 'google_chat' | 'pushover' | 'gotify' | 'ntfy' | 'smtp' | 'webhook'
   config: Record<string, any>
   enabled: boolean
   created_at: string

--- a/ui/src/features/settings/components/NotificationChannelsSection.tsx
+++ b/ui/src/features/settings/components/NotificationChannelsSection.tsx
@@ -5,7 +5,7 @@
 
 import { useState } from 'react'
 import { Plus, Trash2, Edit, Power, PowerOff, Bell, BellRing, LucideIcon } from 'lucide-react'
-import { Smartphone, Send, MessageSquare, Hash, Mail, Users } from 'lucide-react'
+import { Smartphone, Send, MessageSquare, MessageCircle, Hash, Mail, Users } from 'lucide-react'
 import { useAuth } from '@/features/auth/AuthContext'
 import {
   useNotificationChannels,
@@ -25,6 +25,7 @@ const CHANNEL_ICONS: Record<string, LucideIcon> = {
   discord: MessageSquare,
   slack: Hash,
   teams: Users,
+  google_chat: MessageCircle,
   pushover: Smartphone,
   gotify: Bell,
   ntfy: BellRing,


### PR DESCRIPTION
Hi,

Thank you for all the nice work on dockmon!

I've created a PR for having added Google Chat as a dedicated notification channel. I read in issue #36 that you should be able to use Google Chat with using the regular webhook channel. This is unfortunately not the case due to Google Chat requiring _text_, _cards_ or _cardsv2_. Without those present and using the regular webhook channel it returns 400 bad request. 

The current webhook implementation sends _title_, _message_, _timestamp_, therefore it is not compatible with Google Chat. Adding a new notification channel seemed the best to me, since Teams for example also has their own channel. 

I've tested my code by building the docker image locally and testing, it seems to work perfectly fine.

Thank you in advance for reviewing my PR, and I look forward to your response.

<img width="1231" height="698" alt="image" src="https://github.com/user-attachments/assets/1336d7ce-ac52-4f5c-8b93-c4b76c8ebe65" />
