### PR TITLE
Added new Event Type for Alerts when a container starts

### DIFF
--- a/backend/alerts/engine.py
+++ b/backend/alerts/engine.py
@@ -655,6 +655,11 @@ class AlertEngine:
             # Container stopped/exited (includes clean stops with exit 0 and crashes)
             return event_type == "state_change" and event_data and event_data.get("new_state") in ["stopped", "exited", "dead"]
 
+        if rule.kind == "container_started":
+            # Container started/now running (fires when container transitions to running state,
+            # regardless of what triggered it — manual start, host reboot recovery, etc.)
+            return event_type == "state_change" and event_data and event_data.get("new_state") == "running"
+
         if rule.kind in ["container_restart", "container_restarted"]:
             # Container restarted (went through restart cycle)
             return event_type == "state_change" and event_data and event_data.get("new_state") == "restarting"

--- a/backend/alerts/evaluation_service.py
+++ b/backend/alerts/evaluation_service.py
@@ -1228,7 +1228,7 @@ class AlertEvaluationService:
 
             # Auto-clear opposite-state alerts before evaluating new rules
             # If container started, clear any container_stopped alerts
-            # If container stopped, clear any container_started alerts (if we add those)
+            # If container stopped, clear any container_started alerts
             if event_type == "state_change" and event_data:
                 new_state = event_data.get("new_state")
 
@@ -1251,6 +1251,16 @@ class AlertEvaluationService:
                     if cleared > 0:
                         logger.info(f"Cleared {cleared} pending container_stopped alert(s) for {container_name}")
 
+                    # Cancel any pending clears for container_started (if it was being cleared
+                    # during a transient stop, cancel the clear since container is running again)
+                    cancelled = self.engine.cancel_pending_clears_for_scope(
+                        scope_type="container",
+                        scope_id=make_composite_key(host_id, container_id),
+                        kinds=["container_started"]
+                    )
+                    if cancelled > 0:
+                        logger.info(f"Cancelled {cancelled} pending clear(s) for {container_name} (container started again)")
+
                 # Container became healthy → clear unhealthy alerts
                 elif new_state == "healthy":
                     await self._auto_clear_alerts_by_kind(
@@ -1270,6 +1280,7 @@ class AlertEvaluationService:
 
                 # Container stopped/exited → cancel any pending clears for container_stopped
                 # (Issue #96 - alert_clear_delay_seconds: if container stops again while clear is pending, cancel it)
+                # Also clear any container_started alerts since the container is no longer running
                 elif new_state in ["stopped", "exited", "dead"]:
                     cancelled = self.engine.cancel_pending_clears_for_scope(
                         scope_type="container",
@@ -1278,6 +1289,22 @@ class AlertEvaluationService:
                     )
                     if cancelled > 0:
                         logger.info(f"Cancelled {cancelled} pending clear(s) for {container_name} (container stopped again)")
+
+                    # Auto-clear container_started alerts (container is no longer running)
+                    await self._auto_clear_alerts_by_kind(
+                        scope_type="container",
+                        scope_id=make_composite_key(host_id, container_id),
+                        kinds_to_clear=["container_started"],
+                        reason="Container stopped"
+                    )
+                    # Clear pending container_started alerts (those with alert_active_delay)
+                    cleared = self.engine.clear_pending_for_scope(
+                        scope_type="container",
+                        scope_id=make_composite_key(host_id, container_id),
+                        kinds=["container_started"]
+                    )
+                    if cleared > 0:
+                        logger.info(f"Cleared {cleared} pending container_started alert(s) for {container_name}")
 
                 # Container became unhealthy → cancel any pending clears for unhealthy
                 elif new_state == "unhealthy":

--- a/backend/notifications.py
+++ b/backend/notifications.py
@@ -1253,7 +1253,7 @@ class NotificationService:
             if rule.metric and settings.alert_template_metric:
                 return settings.alert_template_metric
             # Check if it's a state change alert
-            elif rule.kind in ['container_stopped', 'container_restart', 'container_restarted'] and settings.alert_template_state_change:
+            elif rule.kind in ['container_stopped', 'container_started', 'container_restart', 'container_restarted'] and settings.alert_template_state_change:
                 return settings.alert_template_state_change
             # Check if it's a health alert
             elif rule.kind in ['container_unhealthy', 'host_unhealthy', 'health_check_failed'] and settings.alert_template_health:

--- a/ui/src/features/alerts/components/AlertRuleFormModal.tsx
+++ b/ui/src/features/alerts/components/AlertRuleFormModal.tsx
@@ -131,6 +131,14 @@ const RULE_KINDS = [
     scopes: ['container']
   },
   {
+    value: 'container_started',
+    label: 'Container Started / Now Running',
+    description: 'Alert when container transitions to running state — manual start, host reboot recovery, or external trigger',
+    category: 'Container State',
+    requiresMetric: false,
+    scopes: ['container']
+  },
+  {
     value: 'container_restart',
     label: 'Container Restarted',
     description: 'Alert when container restarts (any restart, expected or unexpected)',


### PR DESCRIPTION
## Add "Container Started / Now Running" alert rule type

### Summary

Adds a new `container_started` alert rule kind that fires whenever a container transitions to the `running` state, regardless of what triggered it — manual CLI start, host reboot recovery, external tool, auto-restart, etc. This complements the existing `container_stopped` (down) and `container_restart` (restart cycle) rules with the "up" side of container lifecycle events.

### Motivation

DockMon covers the "down" side of container lifecycle well (stopped, died, health check failing, restarted), but there's no event-driven way to get notified when a container comes **back up** through external means. This matters in multi-host setups where:
- A container may be started/restarted manually via CLI or another tool
- A container recovers after a host reboot
- Downstream services need to react when a container becomes available (webhooks, status pages, load balancers)

The `Container Restarted` rule only fires when DockMon itself performs the restart. It does not fire for externally-triggered starts.

### Implementation

**4 files changed:**

| File | Change |
|---|---|
| `backend/alerts/engine.py` | Added `container_started` kind in `_rule_matches_event()` — matches `state_change` events where `new_state == "running"` |
| `backend/alerts/evaluation_service.py` | Auto-clears `container_started` alerts when container stops/dies; cancels pending clears on re-start to handle transient stop/start races |
| `backend/notifications.py` | Added `container_started` to the state change template selector (uses existing `{OLD_STATE} → {NEW_STATE}` template) |
| `ui/.../AlertRuleFormModal.tsx` | Added "Container Started / Now Running" to the rule kind dropdown under Container State |

### How it works

1. Docker event `start` or `restart` arrives → `_handle_docker_event()` emits `CONTAINER_STARTED` with `new_state="running"` via EventBus
2. `evaluate_event()` matches the `container_started` rule kind against `new_state == "running"`
3. Notification fires with `{OLD_STATE}` → `{NEW_STATE}` template variables
4. When the container later stops, `container_started` alerts are auto-cleared (if `auto_resolve_on_clear` is enabled on the rule)
5. Supports all standard rule features: `alert_active_delay`, `notification_cooldown`, host/container/tag selectors, `suppress_during_updates`, custom templates

### Usage

Create a new alert rule in the UI with kind **"Container Started / Now Running"** under Container State. No metric required — it's event-driven. Configure selectors and notification channels as usual.
