### PR TITLE
fix: stats chart rendering and history data consistency

### DIFF
--- a/backend/agent/websocket_handler.py
+++ b/backend/agent/websocket_handler.py
@@ -734,7 +734,9 @@ class AgentWebSocketHandler:
                     container_key=container_key,
                     cpu=cpu,
                     mem=mem,
-                    net=net_bytes_per_sec  # Use calculated rate, not cumulative total
+                    net=net_bytes_per_sec,  # Use calculated rate, not cumulative total
+                    memory_used_bytes=stats.get("memory_usage"),
+                    memory_limit_bytes=stats.get("memory_limit")
                 )
 
             # Cache latest full stats for REST API endpoints (not just sparkline data)

--- a/backend/docker_monitor/container_discovery.py
+++ b/backend/docker_monitor/container_discovery.py
@@ -364,9 +364,10 @@ class ContainerDiscovery:
                     tls_cert = db_host.tls_cert if db_host else None
                     tls_key = db_host.tls_key if db_host else None
                     num_cpus = db_host.num_cpus if db_host else None
+                    total_memory = db_host.total_memory if db_host else None
 
                     is_local = host.url.startswith("unix://")
-                    await stats_client.add_docker_host(host_id, host.name, host.url, tls_ca, tls_cert, tls_key, num_cpus, is_local)
+                    await stats_client.add_docker_host(host_id, host.name, host.url, tls_ca, tls_cert, tls_key, num_cpus, total_memory, is_local)
                     await stats_client.add_event_host(host_id, host.name, host.url, tls_ca, tls_cert, tls_key)
                     logger.info(f"Re-registered {host.name} ({host_id[:8]}) with stats/events service after reconnection")
                 except Exception as e:

--- a/backend/docker_monitor/monitor.py
+++ b/backend/docker_monitor/monitor.py
@@ -554,7 +554,7 @@ class DockerMonitor:
                             # Agent hosts have url="agent://" which is not a valid Docker URL
                             if host.connection_type != "agent":
                                 is_local = host.url.startswith("unix://")
-                                await stats_client.add_docker_host(host.id, host.name, host.url, config.tls_ca, config.tls_cert, config.tls_key, host.num_cpus, is_local)
+                                await stats_client.add_docker_host(host.id, host.name, host.url, config.tls_ca, config.tls_cert, config.tls_key, host.num_cpus, host.total_memory, is_local)
                                 logger.info(f"Registered {host.name} ({host.id[:8]}) with stats service")
 
                                 await stats_client.add_event_host(host.id, host.name, host.url, config.tls_ca, config.tls_cert, config.tls_key)
@@ -1192,7 +1192,7 @@ class DockerMonitor:
                         if host.connection_type != "agent":
                             # Re-register with stats service (automatically closes old client)
                             is_local = host.url.startswith("unix://")
-                            await stats_client.add_docker_host(host.id, host.name, host.url, config.tls_ca, config.tls_cert, config.tls_key, host.num_cpus, is_local)
+                            await stats_client.add_docker_host(host.id, host.name, host.url, config.tls_ca, config.tls_cert, config.tls_key, host.num_cpus, host.total_memory, is_local)
                             logger.info(f"Re-registered {host.name} ({host.id[:8]}) with stats service")
 
                             # Remove and re-add event monitoring
@@ -1653,7 +1653,7 @@ class DockerMonitor:
 
                 # Register with stats service
                 is_local = host.url.startswith("unix://")
-                await stats_client.add_docker_host(host_id, host.name, host.url, tls_ca, tls_cert, tls_key, num_cpus, is_local)
+                await stats_client.add_docker_host(host_id, host.name, host.url, tls_ca, tls_cert, tls_key, num_cpus, host.total_memory, is_local)
                 logger.info(f"Registered host {host.name} ({host_id[:8]}) with stats service")
 
                 # Register with event service
@@ -1821,7 +1821,7 @@ class DockerMonitor:
                             # We use is_agent_fed() to distinguish - it tracks if agent is actively sending stats
                             if (host.connection_type == 'agent' and host.status == 'online' and
                                     self.stats_history.is_agent_fed(host_id)):
-                                sparklines = self.stats_history.get_sparklines(host_id, num_points=30)
+                                sparklines = self.stats_history.get_sparklines(host_id)
                                 # Systemd agent is actively sending stats - use them (accurate host-level stats)
                                 host_sparklines[host_id] = sparklines
                                 # Calculate mem_bytes from containers for display purposes
@@ -1892,11 +1892,13 @@ class DockerMonitor:
                                     host_id=host_id,
                                     cpu=total_cpu,
                                     mem=mem_percent,
-                                    net=net_bytes_per_sec
+                                    net=net_bytes_per_sec,
+                                    memory_used_bytes=total_mem_bytes,
+                                    memory_limit_bytes=total_mem_limit
                                 )
 
-                                # Get sparklines for this host (last 30 points)
-                                host_sparklines[host_id] = self.stats_history.get_sparklines(host_id, num_points=30)
+                                # Get the live rolling window for this host.
+                                host_sparklines[host_id] = self.stats_history.get_sparklines(host_id)
 
                         broadcast_data["host_metrics"] = host_metrics
                         broadcast_data["host_sparklines"] = host_sparklines
@@ -1920,11 +1922,13 @@ class DockerMonitor:
                                 container_key=container_key,
                                 cpu=cpu_val,
                                 mem=mem_val,
-                                net=net_val
+                                net=net_val,
+                                memory_used_bytes=container.memory_usage,
+                                memory_limit_bytes=container.memory_limit
                             )
 
                         # Always get sparklines (even for stopped containers) to maintain consistency
-                        sparklines = self.container_stats_history.get_sparklines(container_key, num_points=30)
+                        sparklines = self.container_stats_history.get_sparklines(container_key)
                         container_sparklines[container_key] = sparklines
 
                     broadcast_data["container_sparklines"] = container_sparklines

--- a/backend/docker_monitor/stats_history.py
+++ b/backend/docker_monitor/stats_history.py
@@ -17,9 +17,9 @@ logger = logging.getLogger(__name__)
 # EMA smoothing factor (α = 0.3) as per specs
 EMA_ALPHA = 0.3
 
-# Keep 90 seconds of history at 2-second intervals = 45 data points
-# But we'll store 50 to be safe
-MAX_HISTORY_POINTS = 50
+# Keep 10 minutes of live history at 2-second intervals.
+MAX_HISTORY_POINTS = 300
+DEFAULT_SPARKLINE_POINTS = MAX_HISTORY_POINTS
 
 
 @dataclass
@@ -29,6 +29,8 @@ class HostStatsPoint:
     cpu_percent: float
     mem_percent: float
     net_bytes_per_sec: float
+    memory_used_bytes: Optional[int] = None
+    memory_limit_bytes: Optional[int] = None
 
 
 @dataclass
@@ -38,6 +40,8 @@ class ContainerStatsPoint:
     cpu_percent: float
     mem_percent: float
     net_bytes_per_sec: float
+    memory_used_bytes: Optional[int] = None
+    memory_limit_bytes: Optional[int] = None
 
 
 class StatsHistoryBuffer:
@@ -62,7 +66,9 @@ class StatsHistoryBuffer:
         # host_id -> last update timestamp
         self._agent_fed_hosts: Dict[str, datetime] = {}
 
-    def add_stats(self, host_id: str, cpu: float, mem: float, net: float):
+    def add_stats(self, host_id: str, cpu: float, mem: float, net: float,
+                  memory_used_bytes: Optional[int] = None,
+                  memory_limit_bytes: Optional[int] = None):
         """
         Add a new stats point with EMA smoothing
 
@@ -71,6 +77,8 @@ class StatsHistoryBuffer:
             cpu: CPU usage percentage
             mem: Memory usage percentage
             net: Network bytes per second
+            memory_used_bytes: Memory usage in bytes
+            memory_limit_bytes: Memory limit in bytes
         """
         # Initialize history buffer if needed
         if host_id not in self._history:
@@ -96,7 +104,9 @@ class StatsHistoryBuffer:
             timestamp=datetime.now(timezone.utc),
             cpu_percent=cpu,
             mem_percent=mem,
-            net_bytes_per_sec=net
+            net_bytes_per_sec=net,
+            memory_used_bytes=memory_used_bytes,
+            memory_limit_bytes=memory_limit_bytes
         )
 
         # Add smoothed point to history
@@ -104,42 +114,50 @@ class StatsHistoryBuffer:
             timestamp=datetime.now(timezone.utc),
             cpu_percent=smoothed_cpu,
             mem_percent=smoothed_mem,
-            net_bytes_per_sec=smoothed_net
+            net_bytes_per_sec=smoothed_net,
+            memory_used_bytes=memory_used_bytes,
+            memory_limit_bytes=memory_limit_bytes
         )
 
         self._history[host_id].append(point)
 
-    def get_sparklines(self, host_id: str, num_points: int = 30) -> Dict[str, List[float]]:
+    def get_sparklines(self, host_id: str, num_points: int = DEFAULT_SPARKLINE_POINTS) -> Dict[str, List[float]]:
         """
         Get sparkline data for a host
 
         Args:
             host_id: Host identifier
-            num_points: Number of data points to return (default 30 for UI)
+            num_points: Number of data points to return
 
         Returns:
-            Dict with 'cpu', 'mem', 'net' arrays
+            Dict with 'timestamps', 'cpu', 'mem', 'net' arrays
         """
         if host_id not in self._history or len(self._history[host_id]) == 0:
             # No history yet - return empty arrays
             return {
+                "timestamps": [],
                 "cpu": [],
                 "mem": [],
-                "net": []
+                "net": [],
+                "memory_used_bytes": [],
+                "memory_limit_bytes": []
             }
 
         history = list(self._history[host_id])
 
         # Guard against invalid num_points
         if num_points <= 0:
-            num_points = 30  # Use default
+            num_points = DEFAULT_SPARKLINE_POINTS
 
         # If we have fewer points than requested, return what we have
         if len(history) <= num_points:
             return {
+                "timestamps": [p.timestamp.timestamp() for p in history],
                 "cpu": [p.cpu_percent for p in history],
                 "mem": [p.mem_percent for p in history],
-                "net": [p.net_bytes_per_sec for p in history]
+                "net": [p.net_bytes_per_sec for p in history],
+                "memory_used_bytes": [p.memory_used_bytes for p in history],
+                "memory_limit_bytes": [p.memory_limit_bytes for p in history]
             }
 
         # Sample evenly from history to get requested number of points
@@ -148,9 +166,12 @@ class StatsHistoryBuffer:
         indices = [int(i * step) for i in range(num_points)]
 
         return {
+            "timestamps": [history[i].timestamp.timestamp() for i in indices],
             "cpu": [history[i].cpu_percent for i in indices],
             "mem": [history[i].mem_percent for i in indices],
-            "net": [history[i].net_bytes_per_sec for i in indices]
+            "net": [history[i].net_bytes_per_sec for i in indices],
+            "memory_used_bytes": [history[i].memory_used_bytes for i in indices],
+            "memory_limit_bytes": [history[i].memory_limit_bytes for i in indices]
         }
 
     def cleanup_old_data(self, max_age_seconds: int = 300):
@@ -239,7 +260,9 @@ class ContainerStatsHistoryBuffer:
         # Last raw values for EMA calculation
         self._last_raw: Dict[str, ContainerStatsPoint] = {}
 
-    def add_stats(self, container_key: str, cpu: float, mem: float, net: float):
+    def add_stats(self, container_key: str, cpu: float, mem: float, net: float,
+                  memory_used_bytes: Optional[int] = None,
+                  memory_limit_bytes: Optional[int] = None):
         """
         Add a new stats point with EMA smoothing
 
@@ -248,6 +271,8 @@ class ContainerStatsHistoryBuffer:
             cpu: CPU usage percentage
             mem: Memory usage percentage
             net: Network bytes per second
+            memory_used_bytes: Memory usage in bytes
+            memory_limit_bytes: Memory limit in bytes
         """
         # Initialize history buffer if needed
         if container_key not in self._history:
@@ -273,7 +298,9 @@ class ContainerStatsHistoryBuffer:
             timestamp=datetime.now(timezone.utc),
             cpu_percent=cpu,
             mem_percent=mem,
-            net_bytes_per_sec=net
+            net_bytes_per_sec=net,
+            memory_used_bytes=memory_used_bytes,
+            memory_limit_bytes=memory_limit_bytes
         )
 
         # Add smoothed point to history
@@ -281,42 +308,50 @@ class ContainerStatsHistoryBuffer:
             timestamp=datetime.now(timezone.utc),
             cpu_percent=smoothed_cpu,
             mem_percent=smoothed_mem,
-            net_bytes_per_sec=smoothed_net
+            net_bytes_per_sec=smoothed_net,
+            memory_used_bytes=memory_used_bytes,
+            memory_limit_bytes=memory_limit_bytes
         )
 
         self._history[container_key].append(point)
 
-    def get_sparklines(self, container_key: str, num_points: int = 30) -> Dict[str, List[float]]:
+    def get_sparklines(self, container_key: str, num_points: int = DEFAULT_SPARKLINE_POINTS) -> Dict[str, List[float]]:
         """
         Get sparkline data for a container
 
         Args:
             container_key: Container identifier (composite key: host_id:container_id)
-            num_points: Number of data points to return (default 30 for UI)
+            num_points: Number of data points to return
 
         Returns:
-            Dict with 'cpu', 'mem', 'net' arrays
+            Dict with 'timestamps', 'cpu', 'mem', 'net' arrays
         """
         if container_key not in self._history or len(self._history[container_key]) == 0:
             # No history yet - return empty arrays
             return {
+                "timestamps": [],
                 "cpu": [],
                 "mem": [],
-                "net": []
+                "net": [],
+                "memory_used_bytes": [],
+                "memory_limit_bytes": []
             }
 
         history = list(self._history[container_key])
 
         # Guard against invalid num_points
         if num_points <= 0:
-            num_points = 30  # Use default
+            num_points = DEFAULT_SPARKLINE_POINTS
 
         # If we have fewer points than requested, return what we have
         if len(history) <= num_points:
             return {
+                "timestamps": [p.timestamp.timestamp() for p in history],
                 "cpu": [p.cpu_percent for p in history],
                 "mem": [p.mem_percent for p in history],
-                "net": [p.net_bytes_per_sec for p in history]
+                "net": [p.net_bytes_per_sec for p in history],
+                "memory_used_bytes": [p.memory_used_bytes for p in history],
+                "memory_limit_bytes": [p.memory_limit_bytes for p in history]
             }
 
         # Sample evenly from history to get requested number of points
@@ -324,9 +359,12 @@ class ContainerStatsHistoryBuffer:
         indices = [int(i * step) for i in range(num_points)]
 
         return {
+            "timestamps": [history[i].timestamp.timestamp() for i in indices],
             "cpu": [history[i].cpu_percent for i in indices],
             "mem": [history[i].mem_percent for i in indices],
-            "net": [history[i].net_bytes_per_sec for i in indices]
+            "net": [history[i].net_bytes_per_sec for i in indices],
+            "memory_used_bytes": [history[i].memory_used_bytes for i in indices],
+            "memory_limit_bytes": [history[i].memory_limit_bytes for i in indices]
         }
 
     def cleanup_old_data(self, max_age_seconds: int = 300):

--- a/backend/main.py
+++ b/backend/main.py
@@ -5048,7 +5048,7 @@ async def get_dashboard_hosts(
 
     Returns hosts grouped by tag (if group_by specified) with:
     - Current stats (CPU, Memory, Network)
-    - Sparkline data (last 30-40 data points)
+    - Sparkline data (live rolling window)
     - Top 3 containers by CPU
     - Container count, alerts, updates
     """
@@ -5082,13 +5082,20 @@ async def get_dashboard_hosts(
             total_mem_used = sum(c.memory_usage or 0 for c in running_containers) / (1024 * 1024 * 1024)  # Convert to GB
 
             # Get real sparkline data from stats history buffer (Phase 4c)
-            # Uses EMA smoothing (α = 0.3) and maintains 60-90s of history
+            # Uses EMA smoothing (α = 0.3) and maintains the live rolling window
             # Only use sparklines for online hosts to avoid showing stale data
             if host.status == 'online':
-                sparklines = monitor.stats_history.get_sparklines(host.id, num_points=30)
+                sparklines = monitor.stats_history.get_sparklines(host.id)
             else:
                 # Offline hosts get empty sparklines (no stale data)
-                sparklines = {"cpu": [], "mem": [], "net": []}
+                sparklines = {
+                    "timestamps": [],
+                    "cpu": [],
+                    "mem": [],
+                    "net": [],
+                    "memory_used_bytes": [],
+                    "memory_limit_bytes": [],
+                }
 
             # Get actual host total memory (convert from bytes to GB)
             # FIX: Use real host memory instead of hard-coded 16 GB
@@ -6043,7 +6050,7 @@ async def websocket_endpoint(websocket: WebSocket, session_id: Optional[str] = C
                 for container in containers_data:
                     # Use composite key with SHORT ID: host_id:container_id (12 chars)
                     container_key = make_composite_key(container.host_id, container.short_id)
-                    sparklines = monitor.container_stats_history.get_sparklines(container_key, num_points=30)
+                    sparklines = monitor.container_stats_history.get_sparklines(container_key)
                     container_sparklines[container_key] = sparklines
                 broadcast_data["container_sparklines"] = container_sparklines
 

--- a/backend/stats_client.py
+++ b/backend/stats_client.py
@@ -114,7 +114,7 @@ class StatsServiceClient:
                 return False
         return False
 
-    async def add_docker_host(self, host_id: str, host_name: str, host_address: str, tls_ca: str = None, tls_cert: str = None, tls_key: str = None, num_cpus: int = None, is_local: bool = False) -> bool:
+    async def add_docker_host(self, host_id: str, host_name: str, host_address: str, tls_ca: str = None, tls_cert: str = None, tls_key: str = None, num_cpus: int = None, total_memory: int = None, is_local: bool = False) -> bool:
         """Register a Docker host with the stats service"""
         for attempt in range(2):
             try:
@@ -134,6 +134,10 @@ class StatsServiceClient:
                 # Add num_cpus for proper host CPU aggregation
                 if num_cpus and num_cpus > 0:
                     payload["num_cpus"] = num_cpus
+
+                # Add Docker-visible memory for proper host memory aggregation
+                if total_memory and total_memory > 0:
+                    payload["total_memory"] = total_memory
 
                 # Mark as local host for /host/proc reading (Issue #129)
                 if is_local:

--- a/stats-service/aggregator.go
+++ b/stats-service/aggregator.go
@@ -222,8 +222,12 @@ func (a *Aggregator) aggregateHostStats(hostID string, containers []*ContainerSt
 		cpuPercent = totalCPU // Fallback if numCPUs not set
 	}
 
-	if totalMemLimit > 0 {
-		memPercent = (float64(totalMemUsage) / float64(totalMemLimit)) * 100.0
+	hostMemLimit := a.cache.GetHostMemory(hostID)
+	if hostMemLimit == 0 {
+		hostMemLimit = totalMemLimit
+	}
+	if hostMemLimit > 0 {
+		memPercent = (float64(totalMemUsage) / float64(hostMemLimit)) * 100.0
 	}
 
 	// Round to 1 decimal place - using shared package
@@ -235,7 +239,7 @@ func (a *Aggregator) aggregateHostStats(hostID string, containers []*ContainerSt
 		CPUPercent:       cpuPercent,
 		MemoryPercent:    memPercent,
 		MemoryUsedBytes:  totalMemUsage,
-		MemoryLimitBytes: totalMemLimit,
+		MemoryLimitBytes: hostMemLimit,
 		NetworkRxBytes:   totalNetRx,
 		NetworkTxBytes:   totalNetTx,
 		ContainerCount:   validContainers,

--- a/stats-service/aggregator_cascade_test.go
+++ b/stats-service/aggregator_cascade_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	dockerpkg "github.com/darthnorse/dockmon-shared/docker"
 	"github.com/dockmon/stats-service/persistence"
 )
 
@@ -49,6 +50,39 @@ func TestAggregator_FeedsCascade(t *testing.T) {
 	// container samples by checking state size via the test-only helper.
 	if got := cascade.StateSize(); got != 2 {
 		t.Errorf("cascade state size=%d, want 2 (1 container + 1 host)", got)
+	}
+}
+
+func TestAggregator_HostMemoryUsesDockerHostLimit(t *testing.T) {
+	cache := NewStatsCache()
+	const hostLimit = uint64(6 * 1024 * 1024 * 1024)
+	const containerUsage = uint64(1024 * 1024 * 1024)
+	const containerLimit = uint64(16 * 1024 * 1024 * 1024)
+	cache.SetHostMemory("host-1", hostLimit)
+	cache.UpdateContainerStats(&ContainerStats{
+		ContainerID:   "aaaaaaaaaaaa",
+		HostID:        "host-1",
+		MemoryUsage:   containerUsage,
+		MemoryLimit:   containerLimit,
+		MemoryPercent: 6.25,
+	})
+
+	agg := &Aggregator{
+		cache:             cache,
+		streamManager:     stubStreamManager{},
+		aggregateInterval: time.Second,
+		hostProcReader:    NewHostProcReader(),
+	}
+
+	got := agg.aggregateHostStats("host-1", []*ContainerStats{
+		cache.containerStats["host-1:aaaaaaaaaaaa"],
+	})
+	if got.MemoryLimitBytes != hostLimit {
+		t.Fatalf("MemoryLimitBytes=%d, want Docker host limit %d", got.MemoryLimitBytes, hostLimit)
+	}
+	wantPercent := dockerpkg.RoundToDecimal(float64(containerUsage)/float64(hostLimit)*100, 1)
+	if got.MemoryPercent != wantPercent {
+		t.Fatalf("MemoryPercent=%v, want %v", got.MemoryPercent, wantPercent)
 	}
 }
 

--- a/stats-service/cache.go
+++ b/stats-service/cache.go
@@ -8,32 +8,32 @@ import (
 
 // ContainerStats holds real-time stats for a single container
 type ContainerStats struct {
-	ContainerID     string    `json:"container_id"`
-	ContainerName   string    `json:"container_name"`
-	HostID          string    `json:"host_id"`
-	CPUPercent      float64   `json:"cpu_percent"`
-	MemoryUsage     uint64    `json:"memory_usage"`
-	MemoryLimit     uint64    `json:"memory_limit"`
-	MemoryPercent   float64   `json:"memory_percent"`
-	NetworkRx       uint64    `json:"network_rx"`
-	NetworkTx       uint64    `json:"network_tx"`
-	NetBytesPerSec  float64   `json:"net_bytes_per_sec"`  // Calculated network rate
-	DiskRead        uint64    `json:"disk_read"`
-	DiskWrite       uint64    `json:"disk_write"`
-	LastUpdate      time.Time `json:"last_update"`
+	ContainerID    string    `json:"container_id"`
+	ContainerName  string    `json:"container_name"`
+	HostID         string    `json:"host_id"`
+	CPUPercent     float64   `json:"cpu_percent"`
+	MemoryUsage    uint64    `json:"memory_usage"`
+	MemoryLimit    uint64    `json:"memory_limit"`
+	MemoryPercent  float64   `json:"memory_percent"`
+	NetworkRx      uint64    `json:"network_rx"`
+	NetworkTx      uint64    `json:"network_tx"`
+	NetBytesPerSec float64   `json:"net_bytes_per_sec"` // Calculated network rate
+	DiskRead       uint64    `json:"disk_read"`
+	DiskWrite      uint64    `json:"disk_write"`
+	LastUpdate     time.Time `json:"last_update"`
 }
 
 // HostStats holds aggregated stats for a host
 type HostStats struct {
-	HostID            string    `json:"host_id"`
-	CPUPercent        float64   `json:"cpu_percent"`
-	MemoryPercent     float64   `json:"memory_percent"`
-	MemoryUsedBytes   uint64    `json:"memory_used_bytes"`
-	MemoryLimitBytes  uint64    `json:"memory_limit_bytes"`
-	NetworkRxBytes    uint64    `json:"network_rx_bytes"`
-	NetworkTxBytes    uint64    `json:"network_tx_bytes"`
-	ContainerCount    int       `json:"container_count"`
-	LastUpdate        time.Time `json:"last_update"`
+	HostID           string    `json:"host_id"`
+	CPUPercent       float64   `json:"cpu_percent"`
+	MemoryPercent    float64   `json:"memory_percent"`
+	MemoryUsedBytes  uint64    `json:"memory_used_bytes"`
+	MemoryLimitBytes uint64    `json:"memory_limit_bytes"`
+	NetworkRxBytes   uint64    `json:"network_rx_bytes"`
+	NetworkTxBytes   uint64    `json:"network_tx_bytes"`
+	ContainerCount   int       `json:"container_count"`
+	LastUpdate       time.Time `json:"last_update"`
 }
 
 // networkBaseline tracks previous network values for rate calculation
@@ -45,11 +45,12 @@ type networkBaseline struct {
 // StatsCache is a thread-safe cache for container and host stats
 type StatsCache struct {
 	mu             sync.RWMutex
-	containerStats map[string]*ContainerStats     // key: composite key (hostID:containerID)
-	hostStats      map[string]*HostStats          // key: hostID
-	lastNetStats   map[string]*networkBaseline    // key: composite key (hostID:containerID)
-	hostNumCPUs    map[string]int                 // key: hostID -> number of CPUs on host
-	localHosts     map[string]bool                // key: hostID -> true if local host
+	containerStats map[string]*ContainerStats  // key: composite key (hostID:containerID)
+	hostStats      map[string]*HostStats       // key: hostID
+	lastNetStats   map[string]*networkBaseline // key: composite key (hostID:containerID)
+	hostNumCPUs    map[string]int              // key: hostID -> number of CPUs on host
+	hostMemory     map[string]uint64           // key: hostID -> total memory available to Docker
+	localHosts     map[string]bool             // key: hostID -> true if local host
 }
 
 // NewStatsCache creates a new stats cache
@@ -59,6 +60,7 @@ func NewStatsCache() *StatsCache {
 		hostStats:      make(map[string]*HostStats),
 		lastNetStats:   make(map[string]*networkBaseline),
 		hostNumCPUs:    make(map[string]int),
+		hostMemory:     make(map[string]uint64),
 		localHosts:     make(map[string]bool),
 	}
 }
@@ -78,6 +80,20 @@ func (c *StatsCache) GetHostNumCPUs(hostID string) int {
 		return numCPUs
 	}
 	return 1 // Default to 1 to avoid division by zero
+}
+
+// SetHostMemory stores the total memory available to Docker for a host.
+func (c *StatsCache) SetHostMemory(hostID string, totalMemory uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.hostMemory[hostID] = totalMemory
+}
+
+// GetHostMemory retrieves the total memory available to Docker for a host.
+func (c *StatsCache) GetHostMemory(hostID string) uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.hostMemory[hostID]
 }
 
 // SetHostLocal marks a host as local (for /host/proc reading)
@@ -240,6 +256,9 @@ func (c *StatsCache) RemoveHostStats(hostID string) {
 
 	// Remove host num_cpus
 	delete(c.hostNumCPUs, hostID)
+
+	// Remove host memory
+	delete(c.hostMemory, hostID)
 
 	// Remove local host flag
 	delete(c.localHosts, hostID)

--- a/stats-service/main.go
+++ b/stats-service/main.go
@@ -347,7 +347,7 @@ func main() {
 			return
 		}
 
-		jsonResponse(w,stats)
+		jsonResponse(w, stats)
 	}))
 
 	// Get all container stats (for debugging) - PROTECTED
@@ -475,6 +475,7 @@ func main() {
 			TLSCert     string `json:"tls_cert,omitempty"`
 			TLSKey      string `json:"tls_key,omitempty"`
 			NumCPUs     int    `json:"num_cpus,omitempty"`
+			TotalMemory uint64 `json:"total_memory,omitempty"`
 			IsLocal     bool   `json:"is_local,omitempty"`
 		}
 
@@ -497,6 +498,11 @@ func main() {
 		// Store number of CPUs for host CPU aggregation
 		if req.NumCPUs > 0 {
 			cache.SetHostNumCPUs(req.HostID, req.NumCPUs)
+		}
+
+		// Store Docker-visible host memory for host memory aggregation
+		if req.TotalMemory > 0 {
+			cache.SetHostMemory(req.HostID, req.TotalMemory)
 		}
 
 		// Mark host as local for /host/proc reading
@@ -628,7 +634,7 @@ func main() {
 			events = eventCache.GetAllRecentEvents(50)
 		}
 
-		jsonResponse(w,events)
+		jsonResponse(w, events)
 	}))
 
 	// WebSocket endpoint for event streaming - PROTECTED

--- a/stats-service/persistence/db.go
+++ b/stats-service/persistence/db.go
@@ -12,6 +12,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"net/url"
 	"slices"
 	"strings"
@@ -203,14 +204,25 @@ func (db *DB) QueryContainerHistory(
 	var out []HistoryRow
 	for rows.Next() {
 		var r HistoryRow
+		var memUsed, memLimit sql.NullFloat64
 		if err := rows.Scan(
-			&r.Timestamp, &r.CPU, &r.MemPercent, &r.MemUsed, &r.MemLimit, &r.NetBps,
+			&r.Timestamp, &r.CPU, &r.MemPercent, &memUsed, &memLimit, &r.NetBps,
 		); err != nil {
 			return nil, fmt.Errorf("scan container history: %w", err)
 		}
+		r.MemUsed = int64PtrFromFloat(memUsed)
+		r.MemLimit = int64PtrFromFloat(memLimit)
 		out = append(out, r)
 	}
 	return out, rows.Err()
+}
+
+func int64PtrFromFloat(v sql.NullFloat64) *int64 {
+	if !v.Valid {
+		return nil
+	}
+	rounded := int64(math.Round(v.Float64))
+	return &rounded
 }
 
 // QueryHostHistory returns rows for one host in [fromUnix, toUnix].

--- a/stats-service/persistence/db_test.go
+++ b/stats-service/persistence/db_test.go
@@ -298,6 +298,42 @@ func TestQueryContainerHistory_ReturnsRows(t *testing.T) {
 	}
 }
 
+func TestQueryContainerHistory_ScansBlendedMemoryBytes(t *testing.T) {
+	path := makeFixtureDB(t)
+	db, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Write().Exec(`INSERT INTO docker_hosts (id,name) VALUES ('h1','h1')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Write().Exec(`INSERT INTO container_stats_history
+		(container_id, host_id, timestamp, resolution, cpu_percent, memory_usage, memory_limit, network_bps)
+		VALUES (?,?,?,?,?,?,?,?)`,
+		"h1:abc123abc123", "h1", int64(1_000_000), "8h",
+		float64(1), float64(234104422.4), float64(536870912), float64(100)); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := db.QueryContainerHistory(
+		context.Background(),
+		"h1:abc123abc123", "8h", 1_000_000, 1_000_000,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if rows[0].MemUsed == nil || *rows[0].MemUsed != 234104422 {
+		t.Errorf("MemUsed=%v, want 234104422", rows[0].MemUsed)
+	}
+	if rows[0].MemLimit == nil || *rows[0].MemLimit != 536870912 {
+		t.Errorf("MemLimit=%v, want 536870912", rows[0].MemLimit)
+	}
+}
+
 func TestQueryContainerHistory_EmptyResult(t *testing.T) {
 	// No rows in the table — the query should return an empty slice (not an
 	// error) so the handler can gap-fill a pure-null response.

--- a/ui/src/features/containers/components/drawer/ContainerOverviewTab.tsx
+++ b/ui/src/features/containers/components/drawer/ContainerOverviewTab.tsx
@@ -294,9 +294,12 @@ export function ContainerOverviewTab({ containerId, actionButtons }: ContainerOv
           hostId={container.host_id || ''}
           containerId={container.id}
           liveData={{
+            timestamps: sparklines?.timestamps,
             cpu: cpuData,
             mem: memData,
             net: netData,
+            memoryUsed: sparklines?.memory_used_bytes,
+            memoryLimit: sparklines?.memory_limit_bytes,
             cpuValue: `${container.cpu_percent?.toFixed(1) || '0.0'}%`,
             memValue: formatBytes(container.memory_usage),
             netValue:

--- a/ui/src/features/containers/components/modal-tabs/ContainerInfoTab.tsx
+++ b/ui/src/features/containers/components/modal-tabs/ContainerInfoTab.tsx
@@ -466,9 +466,12 @@ export function ContainerInfoTab({ container }: ContainerInfoTabProps) {
               hostId={container.host_id || ''}
               containerId={containerShortId}
               liveData={{
+                timestamps: sparklines?.timestamps,
                 cpu: cpuData,
                 mem: memData,
                 net: netData,
+                memoryUsed: sparklines?.memory_used_bytes,
+                memoryLimit: sparklines?.memory_limit_bytes,
                 cpuValue:
                   container.cpu_percent !== null && container.cpu_percent !== undefined
                     ? `${container.cpu_percent.toFixed(1)}%`

--- a/ui/src/features/dashboard/components/ExpandedHostCard.tsx
+++ b/ui/src/features/dashboard/components/ExpandedHostCard.tsx
@@ -38,6 +38,7 @@ import { makeCompositeKeyFrom } from '@/lib/utils/containerKeys'
 import { debug } from '@/lib/debug'
 import { formatBytes, formatNetworkRate } from '@/lib/utils/formatting'
 import { isSafeUrl } from '@/lib/utils/urlSanitize'
+import { LIVE_TIME_WINDOW } from '@/lib/statsConfig'
 
 export interface ExpandedHostData {
   id: string
@@ -57,6 +58,7 @@ export interface ExpandedHostData {
 
   // Sparklines
   sparklines?: {
+    timestamps: number[]
     cpu: number[]
     mem: number[]
     net: number[]
@@ -318,8 +320,10 @@ export function ExpandedHostCard({ host, cardRef, onHostClick, onViewDetails, on
             <div className="flex-1">
               <ResponsiveMiniChart
                 data={host.sparklines!.cpu}
+                timestamps={host.sparklines!.timestamps}
                 color="cpu"
                 height={32}
+                timeWindow={LIVE_TIME_WINDOW}
                 label={`${host.name} CPU usage`}
               />
             </div>
@@ -334,8 +338,10 @@ export function ExpandedHostCard({ host, cardRef, onHostClick, onViewDetails, on
             <div className="flex-1">
               <ResponsiveMiniChart
                 data={host.sparklines!.mem}
+                timestamps={host.sparklines!.timestamps}
                 color="memory"
                 height={32}
+                timeWindow={LIVE_TIME_WINDOW}
                 label={`${host.name} Memory usage`}
               />
             </div>
@@ -351,8 +357,10 @@ export function ExpandedHostCard({ host, cardRef, onHostClick, onViewDetails, on
               {hasValidNetworkData ? (
                 <ResponsiveMiniChart
                   data={host.sparklines!.net}
+                  timestamps={host.sparklines!.timestamps}
                   color="network"
                   height={32}
+                  timeWindow={LIVE_TIME_WINDOW}
                   label={`${host.name} Network I/O`}
                 />
               ) : (

--- a/ui/src/features/dashboard/components/ExpandedHostCardContainer.tsx
+++ b/ui/src/features/dashboard/components/ExpandedHostCardContainer.tsx
@@ -104,6 +104,7 @@ export function ExpandedHostCardContainer({ host, onHostClick, onViewDetails, on
       // Sparklines from WebSocket (only when visible for performance)
       ...(isVisible && sparklines && {
         sparklines: {
+          timestamps: sparklines.timestamps,
           cpu: sparklines.cpu,
           mem: sparklines.mem,
           net: sparklines.net,

--- a/ui/src/features/dashboard/components/HostCard.tsx
+++ b/ui/src/features/dashboard/components/HostCard.tsx
@@ -22,6 +22,7 @@ import { useUserPreferences, useUpdatePreferences, useSimplifiedWorkflow } from 
 import { useContainerModal } from '@/providers'
 import { makeCompositeKeyFrom } from '@/lib/utils/containerKeys'
 import { formatBytes, formatNetworkRate } from '@/lib/utils/formatting'
+import { LIVE_TIME_WINDOW } from '@/lib/statsConfig'
 
 export interface HostCardData {
   id: string
@@ -39,8 +40,9 @@ export interface HostCardData {
     net_bytes_per_sec: number
   }
 
-  // Historical data for sparklines (last 30-40 data points)
+  // Live rolling-window data for sparklines
   sparklines?: {
+    timestamps: number[]
     cpu: number[]
     mem: number[]
     net: number[]
@@ -272,8 +274,10 @@ export function HostCard({ host, onHostClick, onViewDetails, onEditHost }: HostC
             <div className="flex-1">
               <ResponsiveMiniChart
                 data={host.sparklines!.cpu}
+                timestamps={host.sparklines!.timestamps}
                 color="cpu"
                 height={32}
+                timeWindow={LIVE_TIME_WINDOW}
                 label={`${host.name} CPU usage`}
               />
             </div>
@@ -288,8 +292,10 @@ export function HostCard({ host, onHostClick, onViewDetails, onEditHost }: HostC
             <div className="flex-1">
               <ResponsiveMiniChart
                 data={host.sparklines!.mem}
+                timestamps={host.sparklines!.timestamps}
                 color="memory"
                 height={32}
+                timeWindow={LIVE_TIME_WINDOW}
                 label={`${host.name} Memory usage`}
               />
             </div>
@@ -305,8 +311,10 @@ export function HostCard({ host, onHostClick, onViewDetails, onEditHost }: HostC
               {hasValidNetworkData ? (
                 <ResponsiveMiniChart
                   data={host.sparklines!.net}
+                  timestamps={host.sparklines!.timestamps}
                   color="network"
                   height={32}
+                  timeWindow={LIVE_TIME_WINDOW}
                   label={`${host.name} Network I/O`}
                 />
               ) : (

--- a/ui/src/features/dashboard/components/HostCardContainer.tsx
+++ b/ui/src/features/dashboard/components/HostCardContainer.tsx
@@ -50,6 +50,7 @@ export function HostCardContainer({ host, onHostClick, onViewDetails, onEditHost
     // Sparklines from WebSocket
     ...(sparklines && {
       sparklines: {
+        timestamps: sparklines.timestamps,
         cpu: sparklines.cpu,
         mem: sparklines.mem,
         net: sparklines.net,

--- a/ui/src/features/hosts/components/drawer/HostPerformanceSection.tsx
+++ b/ui/src/features/hosts/components/drawer/HostPerformanceSection.tsx
@@ -23,9 +23,12 @@ export function HostPerformanceSection({ hostId }: HostPerformanceSectionProps) 
       <StatsSection
         hostId={hostId}
         liveData={{
+          timestamps: sparklines?.timestamps,
           cpu: sparklines?.cpu ?? [],
           mem: sparklines?.mem ?? [],
           net: sparklines?.net ?? [],
+          memoryUsed: sparklines?.memory_used_bytes,
+          memoryLimit: sparklines?.memory_limit_bytes,
           cpuValue:
             metrics?.cpu_percent !== undefined
               ? `${metrics.cpu_percent.toFixed(1)}%`

--- a/ui/src/features/hosts/components/modal-tabs/HostOverviewTab.tsx
+++ b/ui/src/features/hosts/components/modal-tabs/HostOverviewTab.tsx
@@ -327,14 +327,20 @@ export function HostOverviewTab({ hostId, host }: HostOverviewTabProps) {
             <StatsSection
               hostId={hostId}
               liveData={{
+                timestamps: sparklines?.timestamps,
                 cpu: sparklines?.cpu ?? [],
                 mem: sparklines?.mem ?? [],
                 net: sparklines?.net ?? [],
+                memoryUsed: sparklines?.memory_used_bytes,
+                memoryLimit: sparklines?.memory_limit_bytes,
                 cpuValue:
                   metrics?.cpu_percent !== undefined
                     ? `${metrics.cpu_percent.toFixed(1)}%`
                     : undefined,
-                memValue: metrics?.mem_bytes ? formatBytes(metrics.mem_bytes) : undefined,
+                memValue:
+                  metrics?.mem_percent !== undefined
+                    ? `${metrics.mem_percent.toFixed(1)}%`
+                    : undefined,
                 netValue:
                   metrics?.net_bytes_per_sec !== undefined
                     ? formatNetworkRate(metrics.net_bytes_per_sec)

--- a/ui/src/lib/charts/MiniChart.tsx
+++ b/ui/src/lib/charts/MiniChart.tsx
@@ -2,12 +2,12 @@
  * MiniChart — uPlot-backed sparkline with two operating modes:
  *
  * - **Index mode** (default): live sparkline driven by an array of values.
- *   X-axis is index-based with relative "seconds ago" labels. Used by every
- *   dashboard / drawer card today.
+ *   X-axis is index-based with relative "seconds ago" labels. Used only as a
+ *   fallback when live sparklines do not include timestamps.
  * - **Timestamp mode**: pass `timestamps` (unix seconds) alongside the data
  *   array. X-axis becomes absolute time, nulls in `data` render as gaps,
  *   `timeWindow` locks the X-axis to a rolling [now - timeWindow, now] view.
- *   Used for historical views over arbitrary ranges.
+ *   Used for historical views and timestamped live sparklines.
  *
  * Tens of MiniChart instances can be visible at once on the dashboard, so the
  * named export is wrapped in `React.memo` and uPlot data updates flow through
@@ -23,6 +23,7 @@ import { formatRelativeTime, formatYAxisValue } from './formatters'
 // Color palette matching design system. Single source of truth: any UI element
 // that visually represents a metric (chart line, icon, swatch) MUST source its
 // color from here so the icon and the line can never disagree.
+// eslint-disable-next-line react-refresh/only-export-components
 export const CHART_COLORS = {
   cpu: '#F59E0B',     // Amber
   memory: '#3B82F6',  // Blue
@@ -46,7 +47,7 @@ export interface MiniChartProps {
   label?: string | undefined
   /** Show axes and enhanced features (default: false for compact sparklines) */
   showAxes?: boolean | undefined
-  /** Fixed rolling time window in seconds. When provided with timestamps, X-axis is locked to [now - timeWindow, now]. */
+  /** Fixed rolling time window in seconds for timestamp mode. */
   timeWindow?: number | undefined
   /**
    * Tooltip time formatter for timestamp mode. Receives unix seconds, returns
@@ -55,7 +56,14 @@ export interface MiniChartProps {
    * reference** (use `useCallback`) — a new identity per render forces uPlot
    * to rebuild on every WS tick.
    */
+  // eslint-disable-next-line no-unused-vars
   formatTooltipTime?: ((unixSec: number) => string) | undefined
+  /** Optional formatter for values shown in the hover tooltip. */
+  // eslint-disable-next-line no-unused-vars
+  formatTooltipValue?: ((value: number, index: number) => string | string[]) | undefined
+  /** Optional formatter for Y-axis tick labels. */
+  // eslint-disable-next-line no-unused-vars
+  formatYAxisTick?: ((value: number) => string) | undefined
 }
 
 /**
@@ -118,6 +126,8 @@ function MiniChartInner({
   showAxes = false,
   timeWindow,
   formatTooltipTime,
+  formatTooltipValue,
+  formatYAxisTick,
 }: MiniChartProps) {
   const chartRef = useRef<HTMLDivElement>(null)
   const plotRef = useRef<uPlot | null>(null)
@@ -126,7 +136,7 @@ function MiniChartInner({
     x: number
     y: number
     time: string
-    value: string
+    value: string | string[]
   }>({
     show: false,
     x: 0,
@@ -274,7 +284,7 @@ function MiniChartInner({
       {
         // Y-axis (values)
         show: showAxes,
-        space: 40,
+        space: formatYAxisTick ? 64 : 40,
         stroke: '#64748b',
         grid: {
           show: showAxes,
@@ -330,6 +340,9 @@ function MiniChartInner({
           return ticks
         },
         values: (_u: uPlot, vals: number[]) => {
+          if (formatYAxisTick) {
+            return vals.map((v: number) => formatYAxisTick(v))
+          }
           return vals.map((v: number) => formatYAxisValue(v, isPercentage))
         },
         font: '11px system-ui, -apple-system, sans-serif',
@@ -388,7 +401,7 @@ function MiniChartInner({
         // Render gaps at null values (for downtime / missing data in historical views)
         spanGaps: false,
         points: {
-          show: showAxes, // Only show points in enhanced mode
+          show: false,
           size: 4,
           stroke: CHART_COLORS[color],
           fill: '#ffffff',
@@ -398,6 +411,10 @@ function MiniChartInner({
           // Format tooltip value based on metric type.
           // With spanGaps: false, uPlot passes null at gap points.
           if (v == null) return '—'
+          if (formatTooltipValue) {
+            const formatted = formatTooltipValue(v, -1)
+            return Array.isArray(formatted) ? formatted.join(' ') : formatted
+          }
           if (isPercentage) {
             return `${v.toFixed(1)}%`
           }
@@ -438,8 +455,10 @@ function MiniChartInner({
             timeLabel = secondsAgo === 0 ? 'now' : `${formatRelativeTime(secondsAgo)} ago`
           }
 
-          let valueLabel: string
-          if (isPercentage) {
+          let valueLabel: string | string[]
+          if (formatTooltipValue) {
+            valueLabel = formatTooltipValue(yVal, idx)
+          } else if (isPercentage) {
             valueLabel = `${yVal.toFixed(1)}%`
           } else {
             valueLabel = formatYAxisValue(yVal, false)
@@ -459,7 +478,7 @@ function MiniChartInner({
         },
       ],
     },
-  }), [width, height, color, label, isPercentage, isCpu, hasTimestamps, timeWindow, showAxes, formatTooltipTime, setTooltip])
+  }), [width, height, color, label, isPercentage, isCpu, hasTimestamps, timeWindow, showAxes, formatTooltipTime, formatTooltipValue, formatYAxisTick, setTooltip])
 
   // Tracks whether we've ever had a populated chart, so we only rebuild on the
   // empty→populated transition (and on opts/color changes), not on every data
@@ -542,7 +561,21 @@ function MiniChartInner({
             boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
           }}
         >
-          <div style={{ fontWeight: '600', marginBottom: '2px' }}>{tooltip.value}</div>
+          {Array.isArray(tooltip.value) ? (
+            tooltip.value.map((line, index) => (
+              <div
+                key={`${line}-${index}`}
+                style={{
+                  fontWeight: index === 0 ? '600' : '400',
+                  marginBottom: index === tooltip.value.length - 1 ? '2px' : '1px',
+                }}
+              >
+                {line}
+              </div>
+            ))
+          ) : (
+            <div style={{ fontWeight: '600', marginBottom: '2px' }}>{tooltip.value}</div>
+          )}
           <div style={{ fontSize: '11px', opacity: 0.8 }}>{tooltip.time}</div>
         </div>
       )}

--- a/ui/src/lib/charts/ResponsiveMiniChart.tsx
+++ b/ui/src/lib/charts/ResponsiveMiniChart.tsx
@@ -29,10 +29,12 @@ function ResponsiveMiniChartInner({
   showAxes,
   timeWindow,
   formatTooltipTime,
+  formatTooltipValue,
+  formatYAxisTick,
 }: ResponsiveMiniChartProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [containerWidth, setContainerWidth] = useState<number>(minWidth)
-  const resizeTimeoutRef = useRef<NodeJS.Timeout>()
+  const resizeTimeoutRef = useRef<ReturnType<typeof globalThis.setTimeout>>()
 
   useEffect(() => {
     const container = containerRef.current
@@ -52,9 +54,9 @@ function ResponsiveMiniChartInner({
     // Debounced so rapid parent resizes don't thrash uPlot.
     const handleResize = (entries: ResizeObserverEntry[]) => {
       if (resizeTimeoutRef.current) {
-        clearTimeout(resizeTimeoutRef.current)
+        globalThis.clearTimeout(resizeTimeoutRef.current)
       }
-      resizeTimeoutRef.current = setTimeout(() => {
+      resizeTimeoutRef.current = globalThis.setTimeout(() => {
         for (const entry of entries) {
           const width = entry.contentRect.width
           if (width > 0) {
@@ -75,7 +77,7 @@ function ResponsiveMiniChartInner({
     return () => {
       resizeObserver.disconnect()
       if (resizeTimeoutRef.current) {
-        clearTimeout(resizeTimeoutRef.current)
+        globalThis.clearTimeout(resizeTimeoutRef.current)
       }
     }
   }, [minWidth, maxWidth, debounceMs])
@@ -92,6 +94,8 @@ function ResponsiveMiniChartInner({
         label={label}
         timeWindow={timeWindow}
         formatTooltipTime={formatTooltipTime}
+        formatTooltipValue={formatTooltipValue}
+        formatYAxisTick={formatYAxisTick}
       />
     </div>
   )

--- a/ui/src/lib/charts/StatsCharts.tsx
+++ b/ui/src/lib/charts/StatsCharts.tsx
@@ -1,14 +1,17 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { Cpu, MemoryStick, Network } from 'lucide-react'
 import { ResponsiveMiniChart } from './ResponsiveMiniChart'
 import { CHART_COLORS } from './MiniChart'
 import { formatTime } from '@/lib/utils/timeFormat'
 import { useTimeFormat } from '@/lib/hooks/useUserPreferences'
+import { formatBytes } from '@/lib/utils/formatting'
 
 interface StatsChartsProps {
   cpu: (number | null)[]
   mem: (number | null)[]
   net: (number | null)[]
+  memoryUsed?: (number | null)[] | undefined
+  memoryLimit?: (number | null)[] | undefined
   timestamps: number[]
   timeWindow: number
   cpuValue?: string | undefined
@@ -26,7 +29,7 @@ const CHARTS = [
 ] as const
 
 export function StatsCharts({
-  cpu, mem, net, timestamps, timeWindow,
+  cpu, mem, net, memoryUsed, memoryLimit, timestamps, timeWindow,
   cpuValue, memValue, netValue, footer,
 }: StatsChartsProps) {
   const { timeFormat } = useTimeFormat()
@@ -37,7 +40,39 @@ export function StatsCharts({
   )
 
   const dataMap = { cpu, mem, net }
-  const valueMap = { cpu: cpuValue, mem: memValue, net: netValue }
+  const memoryUsedRef = useRef(memoryUsed)
+  const memoryLimitRef = useRef(memoryLimit)
+
+  useEffect(() => {
+    memoryUsedRef.current = memoryUsed
+    memoryLimitRef.current = memoryLimit
+  }, [memoryLimit, memoryUsed])
+
+  const latestMemoryLimit = latestNonNull(memoryLimit)
+  const memorySummary = formatLatestMemorySummary(mem, memoryUsed, memoryLimit) ?? memValue
+  const valueMap = { cpu: cpuValue, mem: memorySummary, net: netValue }
+
+  const formatMemoryTooltip = useCallback((pct: number, index: number) => {
+    const pctStr = `${pct.toFixed(1)}%`
+    const usedValues = memoryUsedRef.current
+    const limitValues = memoryLimitRef.current
+    const used = index >= 0 ? usedValues?.[index] : undefined
+    const limit = index >= 0 ? limitValues?.[index] : latestNonNull(limitValues)
+    if (used != null && limit != null && limit > 0) {
+      return [pctStr, `${formatBytes(used)} / ${formatBytes(limit)}`]
+    }
+    if (used != null) {
+      return [pctStr, formatBytes(used)]
+    }
+    return pctStr
+  }, [])
+
+  const formatMemoryAxis = useCallback((pct: number) => {
+    if (latestMemoryLimit == null || latestMemoryLimit <= 0) {
+      return `${Math.round(pct)}%`
+    }
+    return formatBytes((latestMemoryLimit * pct) / 100)
+  }, [latestMemoryLimit])
 
   return (
     <>
@@ -62,6 +97,8 @@ export function StatsCharts({
                 showAxes
                 timeWindow={timeWindow}
                 formatTooltipTime={formatTooltipTime}
+                formatTooltipValue={key === 'mem' ? formatMemoryTooltip : undefined}
+                formatYAxisTick={key === 'mem' ? formatMemoryAxis : undefined}
               />
             ) : (
               <div className="flex items-center justify-center text-muted-foreground text-xs" style={{ height: CHART_HEIGHT }}>
@@ -76,4 +113,45 @@ export function StatsCharts({
       )}
     </>
   )
+}
+
+function latestNonNull(arr: (number | null)[] | undefined): number | undefined {
+  if (!arr) return undefined
+  for (let i = arr.length - 1; i >= 0; i--) {
+    const v = arr[i]
+    if (v !== null && v !== undefined) return v
+  }
+  return undefined
+}
+
+function formatLatestMemorySummary(
+  mem: (number | null)[],
+  memoryUsed: (number | null)[] | undefined,
+  memoryLimit: (number | null)[] | undefined
+): string | undefined {
+  const index = latestNonNullIndex(mem)
+  if (index < 0) return undefined
+
+  const pct = mem[index]
+  if (pct == null) return undefined
+
+  const pctStr = `${Math.round(pct * 10) / 10}%`
+  const used = memoryUsed?.[index]
+  const limit = memoryLimit?.[index]
+
+  if (used != null && limit != null && limit > 0) {
+    return `${pctStr} (${formatBytes(used)} / ${formatBytes(limit)})`
+  }
+  if (used != null) {
+    return `${pctStr} (${formatBytes(used)})`
+  }
+  return pctStr
+}
+
+function latestNonNullIndex(arr: (number | null)[] | undefined): number {
+  if (!arr) return -1
+  for (let i = arr.length - 1; i >= 0; i--) {
+    if (arr[i] !== null && arr[i] !== undefined) return i
+  }
+  return -1
 }

--- a/ui/src/lib/stats/StatsProvider.tsx
+++ b/ui/src/lib/stats/StatsProvider.tsx
@@ -185,7 +185,7 @@ export function useHostMetrics(hostId: string | undefined): HostMetrics | null {
  * Get sparkline data for a specific host
  *
  * @param hostId - The host ID to get sparklines for
- * @returns Sparklines (cpu, mem, net arrays) or null if not available
+ * @returns Sparklines (timestamps, cpu, mem, net arrays) or null if not available
  */
 export function useHostSparklines(hostId: string | undefined): Sparklines | null {
   const { hostSparklines } = useStatsContext()
@@ -354,7 +354,7 @@ export function useContainer(compositeKey: string | null | undefined): Container
  * Get sparkline data for a specific container
  *
  * @param compositeKey - The composite key in format "{host_id}:{container_id}"
- * @returns Sparklines (cpu, mem, net arrays) or null if not available
+ * @returns Sparklines (timestamps, cpu, mem, net arrays) or null if not available
  */
 export function useContainerSparklines(compositeKey: string | null | undefined): Sparklines | null {
   const { containerSparklines } = useStatsContext()

--- a/ui/src/lib/stats/StatsSection.tsx
+++ b/ui/src/lib/stats/StatsSection.tsx
@@ -10,9 +10,12 @@ interface Props {
   hostId: string
   containerId?: string
   liveData: {
+    timestamps?: number[] | undefined
     cpu: (number | null)[]
     mem: (number | null)[]
     net: (number | null)[]
+    memoryUsed?: (number | null)[] | undefined
+    memoryLimit?: (number | null)[] | undefined
     cpuValue?: string | undefined
     memValue?: string | undefined
     netValue?: string | undefined
@@ -37,7 +40,9 @@ export function StatsSection({ hostId, containerId, liveData }: Props) {
           cpu={liveData.cpu}
           mem={liveData.mem}
           net={liveData.net}
-          timestamps={[]}
+          memoryUsed={liveData.memoryUsed}
+          memoryLimit={liveData.memoryLimit}
+          timestamps={liveData.timestamps ?? []}
           timeWindow={LIVE_TIME_WINDOW}
           cpuValue={liveData.cpuValue}
           memValue={liveData.memValue}
@@ -98,6 +103,8 @@ function HistoricalCharts({
       cpu={data.cpu}
       mem={data.mem}
       net={data.net_bps}
+      memoryUsed={data.memory_used_bytes}
+      memoryLimit={data.memory_limit_bytes}
       timestamps={data.timestamps}
       timeWindow={data.tier_seconds}
       cpuValue={formatPercent(data.cpu)}

--- a/ui/src/lib/stats/historyTypes.ts
+++ b/ui/src/lib/stats/historyTypes.ts
@@ -15,8 +15,8 @@ export type HistoricalRange = Exclude<TimeRange, 'live'>
  *
  * Column-major arrays: each array is parallel to `timestamps`.
  * Nulls in the data arrays represent missing buckets (chart gaps).
- * `memory_used_bytes`, `memory_limit_bytes`, `container_count` are only
- * populated for host-history responses.
+ * `memory_used_bytes` and `memory_limit_bytes` are optional companion columns
+ * for richer memory labels; `container_count` is host-only.
  */
 export interface StatsHistoryResponse {
   tier: HistoricalRange

--- a/ui/src/lib/stats/types.ts
+++ b/ui/src/lib/stats/types.ts
@@ -13,9 +13,12 @@ export interface HostMetrics {
 }
 
 export interface Sparklines {
+  timestamps: number[]
   cpu: number[]
   mem: number[]
   net: number[]
+  memory_used_bytes?: (number | null)[]
+  memory_limit_bytes?: (number | null)[]
 }
 
 /**

--- a/ui/src/lib/stats/useStatsHistory.ts
+++ b/ui/src/lib/stats/useStatsHistory.ts
@@ -24,13 +24,26 @@ function maxSlotsFor(range: HistoricalRange, intervalSeconds: number): number {
   return Math.ceil(windowSeconds / safeInterval) + MERGE_SLOT_HEADROOM
 }
 
+function latestFilledTimestamp(data: StatsHistoryResponse): number | undefined {
+  for (let i = data.timestamps.length - 1; i >= 0; i--) {
+    if (data.cpu[i] != null || data.mem[i] != null || data.net_bps[i] != null) {
+      return data.timestamps[i]
+    }
+  }
+  return undefined
+}
+
+function mergeValue<T>(current: T | null | undefined, next: T | null | undefined): T | null {
+  return next == null ? (current ?? null) : next
+}
+
 /**
  * Merge a `since`-poll response into cached data.
  *
- * Contract: the server returns buckets with timestamp > `since`. This function
- * defensively drops any timestamp already present in the cache (insurance
- * against server-contract drift) and trims the leading edge of the series so
- * the length stays within the range's expected slot count.
+ * The stats-service may include a trailing bucket for "now" before that bucket
+ * has been written, represented as nulls. A later poll can return the same
+ * timestamp with real values. Replace those overlap nulls instead of treating
+ * timestamps as append-only, otherwise chart gaps persist until a full reload.
  */
 export function mergeHistoryDelta(
   cached: StatsHistoryResponse,
@@ -38,19 +51,8 @@ export function mergeHistoryDelta(
   range: HistoricalRange,
 ): StatsHistoryResponse {
   const lastCached = cached.timestamps[cached.timestamps.length - 1] ?? -Infinity
-  const keepIndices: number[] = []
-  for (let i = 0; i < next.timestamps.length; i++) {
-    const ts = next.timestamps[i]
-    if (ts !== undefined && ts > lastCached) keepIndices.push(i)
-  }
-  if (keepIndices.length === 0) {
-    // Nothing new; just refresh metadata (server_time, to).
-    return { ...cached, server_time: next.server_time, to: next.to }
-  }
-
-  // keepIndices only contains valid indices from next.timestamps, so arr[i]
-  // is never undefined — the `as T` silences noUncheckedIndexedAccess.
-  const pick = <T>(arr: T[]): T[] => keepIndices.map((i) => arr[i] as T)
+  const indexByTimestamp = new Map<number, number>()
+  cached.timestamps.forEach((ts, i) => indexByTimestamp.set(ts, i))
 
   const merged: StatsHistoryResponse = {
     ...cached,
@@ -59,21 +61,54 @@ export function mergeHistoryDelta(
     // Prefer the server-fresh interval; protects trim math if stats-service
     // points_per_view is changed mid-session.
     interval_seconds: next.interval_seconds,
-    timestamps: [...cached.timestamps, ...pick(next.timestamps)],
-    cpu:     [...cached.cpu,     ...pick(next.cpu)],
-    mem:     [...cached.mem,     ...pick(next.mem)],
-    net_bps: [...cached.net_bps, ...pick(next.net_bps)],
+    timestamps: [...cached.timestamps],
+    cpu: [...cached.cpu],
+    mem: [...cached.mem],
+    net_bps: [...cached.net_bps],
   }
 
-  // Symmetric gating so a column that appears later in the cache's lifetime
-  // is preserved. exactOptionalPropertyTypes forbids explicit undefined, so
-  // we only touch the key when at least one side has it. Length-based guard
-  // (not truthy) because `[]` is truthy in JS but carries no data.
   for (const key of OPTIONAL_COLUMNS) {
     const cachedCol = cached[key]
     const nextCol = next[key]
     if ((cachedCol?.length ?? 0) > 0 || (nextCol?.length ?? 0) > 0) {
-      merged[key] = [...(cachedCol ?? []), ...(nextCol ? pick(nextCol) : [])]
+      merged[key] = [...(cachedCol ?? [])]
+    }
+  }
+
+  for (let i = 0; i < next.timestamps.length; i++) {
+    const ts = next.timestamps[i]
+    if (ts === undefined) continue
+
+    const existingIndex = indexByTimestamp.get(ts)
+    if (existingIndex !== undefined) {
+      merged.cpu[existingIndex] = mergeValue(merged.cpu[existingIndex], next.cpu[i])
+      merged.mem[existingIndex] = mergeValue(merged.mem[existingIndex], next.mem[i])
+      merged.net_bps[existingIndex] = mergeValue(merged.net_bps[existingIndex], next.net_bps[i])
+
+      for (const key of OPTIONAL_COLUMNS) {
+        const col = merged[key]
+        const nextCol = next[key]
+        if (col && nextCol) {
+          col[existingIndex] = mergeValue(col[existingIndex], nextCol[i])
+        }
+      }
+      continue
+    }
+
+    if (ts <= lastCached) continue
+
+    indexByTimestamp.set(ts, merged.timestamps.length)
+    merged.timestamps.push(ts)
+    merged.cpu.push(next.cpu[i] ?? null)
+    merged.mem.push(next.mem[i] ?? null)
+    merged.net_bps.push(next.net_bps[i] ?? null)
+
+    for (const key of OPTIONAL_COLUMNS) {
+      const col = merged[key]
+      const nextCol = next[key]
+      if (col && nextCol) {
+        col.push(nextCol[i] ?? null)
+      }
     }
   }
 
@@ -113,7 +148,7 @@ export function useStatsHistory(
     refetchInterval: POLL_INTERVAL_MS,
     queryFn: async () => {
       const cached = queryClient.getQueryData<StatsHistoryResponse>(queryKey)
-      const lastTs = cached?.timestamps[cached.timestamps.length - 1]
+      const lastTs = cached ? latestFilledTimestamp(cached) : undefined
       const params: Record<string, string | number> =
         cached && lastTs !== undefined
           ? { range, since: lastTs }


### PR DESCRIPTION
Hi, thanks again for taking over and integrating the original persistent stats work.

While testing the current implementation, I noticed a few smaller regressions around the stats widgets and chart rendering after the follow-up changes. This PR is meant as a focused cleanup/fix pass for those issues, keeping the existing direction intact rather than changing the overall implementation approach.

## Summary

- Unifies live, dashboard, and historical stats chart rendering by removing point markers and passing timestamped sparkline data through the shared chart components.
- Fixes host memory semantics so persistent host stats use Docker-visible host memory instead of unrelated system/container aggregate values.
- Fixes historical chart refresh behavior by merging delayed non-null buckets into cached history data.
- Fixes longer-range container history loading by scanning blended memory byte values correctly from aggregated persistence tiers.
- Improved Memory tooltip display