### PR TITLE
fix(search): filter hosts table by name, URL, and tags

### DIFF
--- a/ui/src/features/hosts/HostsPage.tsx
+++ b/ui/src/features/hosts/HostsPage.tsx
@@ -80,7 +80,7 @@ export function HostsPage() {
       </div>
 
       {/* Host Table */}
-      <HostTable onEditHost={handleEditHost} />
+      <HostTable onEditHost={handleEditHost} searchQuery={searchQuery} />
 
       {/* Host Modal */}
       <HostModal

--- a/ui/src/features/hosts/components/HostTable.test.tsx
+++ b/ui/src/features/hosts/components/HostTable.test.tsx
@@ -277,6 +277,90 @@ describe('HostTable', () => {
     })
   })
 
+  describe('search filtering', () => {
+    it('should filter hosts by name', () => {
+      vi.mocked(useHostsModule.useHosts).mockReturnValue({
+        data: mockHosts,
+        isLoading: false,
+        error: null,
+      } as any)
+
+      render(<HostTable searchQuery="production" />)
+
+      expect(screen.getByText('production-server')).toBeInTheDocument()
+      expect(screen.queryByText('dev-server')).not.toBeInTheDocument()
+      expect(screen.queryByText('staging-server')).not.toBeInTheDocument()
+    })
+
+    it('should filter hosts by name case-insensitively', () => {
+      vi.mocked(useHostsModule.useHosts).mockReturnValue({
+        data: mockHosts,
+        isLoading: false,
+        error: null,
+      } as any)
+
+      render(<HostTable searchQuery="PRODUCTION" />)
+
+      expect(screen.getByText('production-server')).toBeInTheDocument()
+      expect(screen.queryByText('dev-server')).not.toBeInTheDocument()
+    })
+
+    it('should filter hosts by URL', () => {
+      vi.mocked(useHostsModule.useHosts).mockReturnValue({
+        data: mockHosts,
+        isLoading: false,
+        error: null,
+      } as any)
+
+      render(<HostTable searchQuery="192.168.1.101" />)
+
+      expect(screen.getByText('dev-server')).toBeInTheDocument()
+      expect(screen.queryByText('production-server')).not.toBeInTheDocument()
+      expect(screen.queryByText('staging-server')).not.toBeInTheDocument()
+    })
+
+    it('should filter hosts by tag', () => {
+      vi.mocked(useHostsModule.useHosts).mockReturnValue({
+        data: mockHosts,
+        isLoading: false,
+        error: null,
+      } as any)
+
+      render(<HostTable searchQuery="qa" />)
+
+      expect(screen.getByText('staging-server')).toBeInTheDocument()
+      expect(screen.queryByText('production-server')).not.toBeInTheDocument()
+      expect(screen.queryByText('dev-server')).not.toBeInTheDocument()
+    })
+
+    it('should show all hosts when search query is empty', () => {
+      vi.mocked(useHostsModule.useHosts).mockReturnValue({
+        data: mockHosts,
+        isLoading: false,
+        error: null,
+      } as any)
+
+      render(<HostTable searchQuery="" />)
+
+      expect(screen.getByText('production-server')).toBeInTheDocument()
+      expect(screen.getByText('dev-server')).toBeInTheDocument()
+      expect(screen.getByText('staging-server')).toBeInTheDocument()
+    })
+
+    it('should show a no-match message when search yields no results', () => {
+      vi.mocked(useHostsModule.useHosts).mockReturnValue({
+        data: mockHosts,
+        isLoading: false,
+        error: null,
+      } as any)
+
+      render(<HostTable searchQuery="nonexistent-host" />)
+
+      expect(screen.getByText('No hosts match your search')).toBeInTheDocument()
+      expect(screen.queryByText('production-server')).not.toBeInTheDocument()
+    })
+  })
+
   describe('empty cells', () => {
     it('should render dash placeholders for unset metric/uptime cells', () => {
       vi.mocked(useHostsModule.useHosts).mockReturnValue({

--- a/ui/src/features/hosts/components/HostTable.tsx
+++ b/ui/src/features/hosts/components/HostTable.tsx
@@ -294,12 +294,25 @@ function Uptime({ daemonStartedAt }: { daemonStartedAt?: string | null | undefin
 
 interface HostTableProps {
   onEditHost?: (host: Host) => void
+  searchQuery?: string
 }
 
-export function HostTable({ onEditHost }: HostTableProps = {}) {
+export function HostTable({ onEditHost, searchQuery = '' }: HostTableProps = {}) {
   const { hasCapability } = useAuth()
   const canManage = hasCapability('hosts.manage')
-  const { data: hosts = [], isLoading, error } = useHosts()
+  const { data: allHosts = [], isLoading, error } = useHosts()
+
+  const hosts = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase()
+    if (!query) return allHosts
+
+    return allHosts.filter((host) => {
+      if (host.name?.toLowerCase().includes(query)) return true
+      if (host.url?.toLowerCase().includes(query)) return true
+      if (host.tags?.some((tag) => tag.toLowerCase().includes(query))) return true
+      return false
+    })
+  }, [allHosts, searchQuery])
   const queryClient = useQueryClient()
   const { data: preferences } = useUserPreferences()
   const updatePreferences = useUpdatePreferences()
@@ -659,11 +672,20 @@ export function HostTable({ onEditHost }: HostTableProps = {}) {
     )
   }
 
-  if (hosts.length === 0) {
+  if (allHosts.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-64 text-muted-foreground">
         <p className="text-lg font-medium">No hosts configured</p>
         <p className="text-sm mt-1">Add your first Docker host to get started</p>
+      </div>
+    )
+  }
+
+  if (hosts.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 text-muted-foreground">
+        <p className="text-lg font-medium">No hosts match your search</p>
+        <p className="text-sm mt-1">Try a different name, URL, or tag</p>
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- Wire the `searchQuery` from `HostsPage` into `HostTable`, which was previously ignored — the search bar had no effect on the displayed hosts.
- Filter hosts by name, URL, or tag (case-insensitive) based on the search query.
- Show a "No hosts match your search" empty state when the filter yields no results, distinct from the "No hosts configured" state.

## Test plan
- [x] Added unit tests for filtering by name, case-insensitivity, URL, and tags
- [x] Added test for empty query showing all hosts
- [x] Added test for no-match empty state

Fixes #240